### PR TITLE
Refactor/#65 retweet action

### DIFF
--- a/src/actions/tweet.js
+++ b/src/actions/tweet.js
@@ -17,7 +17,7 @@ const {
 } = actionStatusMessages;
 const {
   UNKNOWN_ERROR,
-  INVALID_TOKEN,
+  UNAUTHORISED,
   TWEET_NOT_FOUND,
   NON_EXISTENT_USER,
   HAS_BEEN_LIKED,
@@ -66,11 +66,11 @@ export const createTweet = (tweet, token) => {
             actionName: 'createTweet'
           })
         );
-        if (err.response.statusText == 'Unauthorised') {
+        if (err.response.statusText == UNAUTHORISED) {
           dispatch(
             setError({
               errorType: AUTHORISATION_ERROR,
-              errorMessage: INVALID_TOKEN
+              errorMessage: UNAUTHORISED
             })
           );
         } else {
@@ -119,13 +119,22 @@ export const retweet = (id, token) => {
             actionName: 'retweet'
           })
         );
-        if (err.response.data == TWEET_NOT_FOUND) {
-          dispatch(
-            setError({
-              errorType: INVALID_REQUEST,
-              errorMessage: TWEET_NOT_FOUND
-            })
-          );
+        if (err.response) {
+          if (err.response.data == TWEET_NOT_FOUND) {
+            dispatch(
+              setError({
+                errorType: INVALID_REQUEST,
+                errorMessage: TWEET_NOT_FOUND
+              })
+            );
+          } else if (err.response.statusText == UNAUTHORISED) {
+            dispatch(
+              setError({
+                errorType: AUTHORISATION_ERROR,
+                errorMessage: UNAUTHORISED
+              })
+            );
+          }
         } else {
           dispatch(
             setError({
@@ -224,11 +233,11 @@ export const deleteTweet = (id, token) => {
           })
         );
         if (err.response) {
-          if (err.response.statusText == 'Unauthorised') {
+          if (err.response.statusText == UNAUTHORISED) {
             dispatch(
               setError({
                 errorType: AUTHORISATION_ERROR,
-                errorMessage: INVALID_TOKEN
+                errorMessage: UNAUTHORISED
               })
             );
           } else if (err.response.data == TWEET_NOT_FOUND) {
@@ -283,11 +292,11 @@ export const likeTweet = (id, token) => {
           })
         );
         if (err.response) {
-          if (err.response.statusText == 'Unauthorised') {
+          if (err.response.statusText == UNAUTHORISED) {
             dispatch(
               setError({
                 errorType: AUTHORISATION_ERROR,
-                errorMessage: INVALID_TOKEN
+                errorMessage: UNAUTHORISED
               })
             );
           } else if (err.response.data == TWEET_NOT_FOUND) {
@@ -349,11 +358,11 @@ export const unlikeTweet = (id, token) => {
           })
         );
         if (err.response) {
-          if (err.response.statusText == 'Unauthorised') {
+          if (err.response.statusText == UNAUTHORISED) {
             dispatch(
               setError({
                 errorType: AUTHORISATION_ERROR,
-                errorMessage: INVALID_TOKEN
+                errorMessage: UNAUTHORISED
               })
             );
           } else if (err.response.data == TWEET_NOT_FOUND) {

--- a/src/config/const.json
+++ b/src/config/const.json
@@ -32,7 +32,7 @@
     "DUPLICATE_HANDLE": "Duplicate handle",
     "UNKNOWN_ERROR": "Unknown DB error",
     "INVALID_CREDENTIALS": "Invalid email/password combination",
-    "INVALID_TOKEN": "The authentication token is invalid",
+    "UNAUTHORISED": "Unauthorised",
     "TWEET_NOT_FOUND": "Tweet not found",
     "NON_EXISTENT_USER": "User does not exist",
     "HAS_BEEN_LIKED": "User has already liked this tweet",

--- a/src/tests/actions/tweet.test.js
+++ b/src/tests/actions/tweet.test.js
@@ -29,7 +29,7 @@ const {
 } = actionStatusMessages;
 const { UPDATE_USER_TWEETS, SET_USER_TWEETS } = actionTypes.tweet;
 const {
-  INVALID_TOKEN,
+  UNAUTHORISED,
   TWEET_NOT_FOUND,
   NON_EXISTENT_USER,
   HAS_BEEN_LIKED,
@@ -114,7 +114,7 @@ describe('tweet actions', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent();
         request
-          .respondWith({ status: 401, statusText: 'Unauthorised' })
+          .respondWith({ status: 401, statusText: UNAUTHORISED })
           .then(() => {
             actions = store.getActions();
             expect(actions[1]).toEqual({
@@ -124,7 +124,7 @@ describe('tweet actions', () => {
             });
             expect(actions[2]).toEqual({
               type: SET_ERROR_MESSAGE,
-              errorMessage: INVALID_TOKEN,
+              errorMessage: UNAUTHORISED,
               errorType: AUTHORISATION_ERROR
             });
             done();
@@ -185,6 +185,36 @@ describe('tweet actions', () => {
               type: SET_ERROR_MESSAGE,
               errorMessage: TWEET_NOT_FOUND,
               errorType: INVALID_REQUEST
+            });
+            done();
+          });
+      });
+    });
+
+    test('should handle unauthorised requests', done => {
+      store.dispatch(retweet(tweetID));
+      let actions = store.getActions();
+      expect(actions[0]).toEqual({
+        type: SET_ACTION_STATUS,
+        actionStatus: IN_PROGRESS_MESSAGE,
+        actionName: 'retweet'
+      });
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request
+          .respondWith({ status: 401, statusText: UNAUTHORISED })
+          .then(() => {
+            actions = store.getActions();
+            expect(actions[1]).toEqual({
+              type: SET_ACTION_STATUS,
+              actionStatus: FAILED_MESSAGE,
+              actionName: 'retweet'
+            });
+            expect(actions[2]).toEqual({
+              type: SET_ERROR_MESSAGE,
+              errorMessage: UNAUTHORISED,
+              errorType: AUTHORISATION_ERROR
             });
             done();
           });
@@ -324,7 +354,7 @@ describe('tweet actions', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent();
         request
-          .respondWith({ status: 401, statusText: 'Unauthorised' })
+          .respondWith({ status: 401, statusText: UNAUTHORISED })
           .then(() => {
             actions = store.getActions();
             expect(actions[1]).toEqual({
@@ -334,7 +364,7 @@ describe('tweet actions', () => {
             });
             expect(actions[2]).toEqual({
               type: SET_ERROR_MESSAGE,
-              errorMessage: INVALID_TOKEN,
+              errorMessage: UNAUTHORISED,
               errorType: AUTHORISATION_ERROR
             });
             done();
@@ -409,7 +439,7 @@ describe('tweet actions', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent();
         request
-          .respondWith({ status: 401, statusText: 'Unauthorised' })
+          .respondWith({ status: 401, statusText: UNAUTHORISED })
           .then(() => {
             actions = store.getActions();
             expect(actions[1]).toEqual({
@@ -419,7 +449,7 @@ describe('tweet actions', () => {
             });
             expect(actions[2]).toEqual({
               type: SET_ERROR_MESSAGE,
-              errorMessage: INVALID_TOKEN,
+              errorMessage: UNAUTHORISED,
               errorType: AUTHORISATION_ERROR
             });
             done();
@@ -527,7 +557,7 @@ describe('tweet actions', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent();
         request
-          .respondWith({ status: 401, statusText: 'Unauthorised' })
+          .respondWith({ status: 401, statusText: UNAUTHORISED })
           .then(() => {
             actions = store.getActions();
             expect(actions[1]).toEqual({
@@ -537,7 +567,7 @@ describe('tweet actions', () => {
             });
             expect(actions[2]).toEqual({
               type: SET_ERROR_MESSAGE,
-              errorMessage: INVALID_TOKEN,
+              errorMessage: UNAUTHORISED,
               errorType: AUTHORISATION_ERROR
             });
             done();


### PR DESCRIPTION
Refactored `likeTweet` action to handle `401` errors.
closes #65 