### PR TITLE
Refactor/#92 view profile action

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -18,6 +18,8 @@ router.get('/view/:id', (req, res) => {
       }
 
       const userProfile = _.pick(user, [
+        'name',
+        '_id',
         'bio',
         'photo',
         'coverPhoto',

--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -9,7 +9,7 @@ import {
   actionTypes
 } from '../config/const.json';
 
-const { SET_USER_PROFILE } = actionTypes.profile;
+const { SET_USER_PROFILE, VIEW_PROFILE } = actionTypes.profile;
 const {
   IN_PROGRESS_MESSAGE,
   SUCCESS_MESSAGE,
@@ -23,6 +23,11 @@ const apiUrl = process.env.API_URL || '';
 export const setUserProfile = userProfile => ({
   type: SET_USER_PROFILE,
   userProfile
+});
+
+export const viewUserProfile = profile => ({
+  type: VIEW_PROFILE,
+  profile
 });
 
 export const getUserProfile = id => {
@@ -47,6 +52,7 @@ export const getUserProfile = id => {
             actionName: 'getUserProfile'
           })
         );
+
         dispatch(setUserProfile(userProfile));
       })
       .catch(err => {

--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -30,7 +30,7 @@ export const viewUserProfile = profile => ({
   profile
 });
 
-export const getUserProfile = id => {
+export const getUserProfile = (id, currentUser) => {
   return dispatch => {
     const url = `${apiUrl}/profile/view/${id}`;
     dispatch(
@@ -39,10 +39,7 @@ export const getUserProfile = id => {
         actionName: 'getUserProfile'
       })
     );
-    return axios({
-      method: 'get',
-      url
-    })
+    return axios({ method: 'get', url })
       .then(res => {
         const userProfile = res.data;
 
@@ -53,7 +50,11 @@ export const getUserProfile = id => {
           })
         );
 
-        dispatch(setUserProfile(userProfile));
+        if (userProfile.name === currentUser) {
+          dispatch(setUserProfile(userProfile));
+        } else {
+          dispatch(viewUserProfile(userProfile));
+        }
       })
       .catch(err => {
         dispatch(

--- a/src/config/const.json
+++ b/src/config/const.json
@@ -12,7 +12,10 @@
     "error": {
       "SET_ERROR_MESSAGE": "SET_ERROR_MESSAGE"
     },
-    "profile": { "SET_USER_PROFILE": "SET_USER_PROFILE" },
+    "profile": {
+      "SET_USER_PROFILE": "SET_USER_PROFILE",
+      "VIEW_PROFILE": "VIEW_PROFILE"
+    },
     "status": {
       "SET_ACTION_STATUS": "SET_ACTION_STATUS"
     },

--- a/src/reducers/profile.js
+++ b/src/reducers/profile.js
@@ -1,10 +1,12 @@
 import { actionTypes } from '../config/const.json';
-const { SET_USER_PROFILE } = actionTypes.profile;
+const { SET_USER_PROFILE, VIEW_PROFILE } = actionTypes.profile;
 
 export default (state = {}, action) => {
   switch (action.type) {
     case SET_USER_PROFILE:
       return { ...state, userProfile: action.userProfile };
+    case VIEW_PROFILE:
+      return { ...state, viewedProfile: action.profile };
     default:
       break;
   }

--- a/src/tests/actions/profile.test.js
+++ b/src/tests/actions/profile.test.js
@@ -18,14 +18,8 @@ const {
   IN_PROGRESS_MESSAGE,
   FAILED_MESSAGE
 } = actionStatusMessages;
-const { SET_USER_PROFILE } = actionTypes.profile;
-const {
-  UNAUTHORISED,
-  TWEET_NOT_FOUND,
-  NON_EXISTENT_USER,
-  HAS_BEEN_LIKED,
-  HAS_NOT_BEEN_LIKED
-} = errorMessages;
+const { SET_USER_PROFILE, VIEW_PROFILE } = actionTypes.profile;
+const { UNAUTHORISED, NON_EXISTENT_USER } = errorMessages;
 const { AUTHORISATION_ERROR, INVALID_REQUEST } = errorTypes;
 
 const createMockStore = configureMockStore([thunk]);
@@ -52,8 +46,8 @@ describe('profile actions', () => {
   });
 
   describe('getUserProfile', () => {
-    test('should handle successful requests', done => {
-      store.dispatch(getUserProfile(userID));
+    test("should handle successful requests to view the authenticated user's own profile", done => {
+      store.dispatch(getUserProfile(userID, profile.name));
       let actions = store.getActions();
       expect(actions[0]).toEqual({
         type: SET_ACTION_STATUS,
@@ -78,6 +72,35 @@ describe('profile actions', () => {
             expect(actions[2]).toEqual({
               type: SET_USER_PROFILE,
               userProfile: profile
+            });
+            done();
+          });
+      });
+    });
+
+    test("should handle successful requests to view a different user's profile", done => {
+      store.dispatch(getUserProfile(userID, profile.name));
+      let actions = store.getActions();
+      expect(actions[0]).toEqual({
+        type: SET_ACTION_STATUS,
+        actionStatus: IN_PROGRESS_MESSAGE,
+        actionName: 'getUserProfile'
+      });
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request
+          .respondWith({ status: 200, response: userProfiles[1] })
+          .then(() => {
+            actions = store.getActions();
+            expect(actions[1]).toEqual({
+              type: SET_ACTION_STATUS,
+              actionStatus: SUCCESS_MESSAGE,
+              actionName: 'getUserProfile'
+            });
+            expect(actions[2]).toEqual({
+              type: VIEW_PROFILE,
+              profile: userProfiles[1]
             });
             done();
           });

--- a/src/tests/reducers/profile.test.js
+++ b/src/tests/reducers/profile.test.js
@@ -1,14 +1,22 @@
 import profileReducer from '../../reducers/profile';
 
+import { userProfiles } from '../seed/seed';
 import { actionTypes } from '../../config/const.json';
-const { SET_USER_PROFILE } = actionTypes.profile;
+const { SET_USER_PROFILE, VIEW_PROFILE } = actionTypes.profile;
+
+let profile;
 
 test('should set the user profile', () => {
-  const userProfile = {
-    bio: 'I am a professional QA tester'
-  };
-  const state = profileReducer({}, { type: SET_USER_PROFILE, userProfile });
-  expect(state).toEqual({
-    userProfile
-  });
+  profile = userProfiles[0];
+  const state = profileReducer(
+    {},
+    { type: SET_USER_PROFILE, userProfile: profile }
+  );
+  expect(state).toEqual({ userProfile: profile });
+});
+
+test('should set the profile currently being viewed', () => {
+  profile = userProfiles[1];
+  const state = profileReducer({}, { type: VIEW_PROFILE, profile });
+  expect(state).toEqual({ viewedProfile: profile });
 });

--- a/src/tests/seed/seed.js
+++ b/src/tests/seed/seed.js
@@ -42,6 +42,7 @@ export const tweets = [
 
 export const userProfiles = [
   {
+    name: users[0].name,
     bio:
       'Award-winning entrepreneur. Professional analyst. Creator. Travel advocate.',
     coverPhoto:
@@ -50,6 +51,7 @@ export const userProfiles = [
       'https://images.pexels.com/photos/1409980/pexels-photo-1409980.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940'
   },
   {
+    name: users[1].name,
     bio:
       'Award-winning entrepreneur. Professional analyst. Creator. Travel advocate.',
     coverPhoto:
@@ -58,6 +60,7 @@ export const userProfiles = [
       'https://images.pexels.com/photos/1399282/pexels-photo-1399282.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=350'
   },
   {
+    name: users[2].name,
     bio:
       'Award-winning entrepreneur. Professional analyst. Creator. Travel advocate.',
     coverPhoto:


### PR DESCRIPTION
Created and tested `viewUserProfile` action. Refactored `getUserProfile` action to dispatch different action depending on whether or not the requested profile is that of the authenticated user's or a different user
closes #92 