### PR TITLE
Refactor/#93 follow and unfollow actions

### DIFF
--- a/config/const.json
+++ b/config/const.json
@@ -1,8 +1,8 @@
 {
   "actionStatusMessages": {
-    "SUCCESS_MESSAGE": "Successful",
+    "FAILED_MESSAGE": "Failed",
     "IN_PROGRESS_MESSAGE": "In Progress",
-    "FAILED_MESSAGE": "Failed"
+    "SUCCESS_MESSAGE": "Successful"
   },
   "actionTypes": {
     "auth": {
@@ -20,30 +20,31 @@
       "SET_ACTION_STATUS": "SET_ACTION_STATUS"
     },
     "tweet": {
-      "UPDATE_USER_TWEETS": "UPDATE_USER_TWEETS",
-      "SET_USER_TWEETS": "SET_USER_TWEETS"
+      "SET_USER_TWEETS": "SET_USER_TWEETS",
+      "UPDATE_USER_TWEETS": "UPDATE_USER_TWEETS"
     }
   },
   "errorTypes": {
-    "DB_ERROR": "DB Error",
     "AUTHENTICATION_ERROR": "Authentication Error",
     "AUTHORISATION_ERROR": "Authorisation Error",
+    "DB_ERROR": "DB Error",
     "INVALID_REQUEST": "Invalid Request"
   },
   "errorMessages": {
-    "VALIDATION_ERROR": "Validation Error",
+    "CANT_BE_FOLLOWED": "Users cannot follow themselves",
     "DUPLICATE_EMAIL": "Duplicate email",
     "DUPLICATE_HANDLE": "Duplicate handle",
-    "UNKNOWN_ERROR": "Unknown DB error",
-    "INVALID_CREDENTIALS": "Invalid email/password combination",
-    "UNAUTHORISED": "Unauthorised",
-    "TWEET_NOT_FOUND": "Tweet not found",
-    "TWEETS_NOT_FOUND": "User has yet to tweet anything",
-    "USER_NOT_FOUND": "User not found",
     "HAS_BEEN_LIKED": "User has already liked this tweet",
     "HAS_NOT_BEEN_LIKED": "User has yet to like this tweet",
     "HAS_BEEN_RETWEETED": "Cannot retweet the same tweet more than once",
     "HAS_BEEN_FOLLOWED": "Already following user",
-    "HAS_NOT_BEEN_FOLLOWED": "User is not currently being followed"
+    "HAS_NOT_BEEN_FOLLOWED": "User is not currently being followed",
+    "INVALID_CREDENTIALS": "Invalid email/password combination",
+    "TWEET_NOT_FOUND": "Tweet not found",
+    "TWEETS_NOT_FOUND": "User has yet to tweet anything",
+    "UNKNOWN_ERROR": "Unknown DB error",
+    "UNAUTHORISED": "Unauthorised",
+    "USER_NOT_FOUND": "User not found",
+    "VALIDATION_ERROR": "Validation Error"
   }
 }

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -7,9 +7,10 @@ const User = require('../models/user');
 const { errorMessages } = require('../../config/const.json');
 
 const {
-  USER_NOT_FOUND,
+  CANT_BE_FOLLOWED,
   HAS_BEEN_FOLLOWED,
-  HAS_NOT_BEEN_FOLLOWED
+  HAS_NOT_BEEN_FOLLOWED,
+  USER_NOT_FOUND
 } = errorMessages;
 const router = express.Router();
 
@@ -56,6 +57,11 @@ router.patch('/edit', authenticate, (req, res) => {
 router.patch('/follow/:id', authenticate, (req, res) => {
   const id = req.params.id;
   const user = req.user;
+
+  if (id === user._id.toHexString()) {
+    return res.status(400).send(CANT_BE_FOLLOWED);
+  }
+
   const follower = {
     _id: user._id,
     user: {

--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -16,11 +16,12 @@ const {
   SUCCESS_MESSAGE
 } = actionStatusMessages;
 const {
-  USER_NOT_FOUND,
+  CANT_BE_FOLLOWED,
+  HAS_BEEN_FOLLOWED,
+  HAS_NOT_BEEN_FOLLOWED,
   UNKNOWN_ERROR,
   UNAUTHORISED,
-  HAS_BEEN_FOLLOWED,
-  HAS_NOT_BEEN_FOLLOWED
+  USER_NOT_FOUND
 } = errorMessages;
 const { AUTHORISATION_ERROR, DB_ERROR, INVALID_REQUEST } = errorTypes;
 
@@ -138,6 +139,20 @@ export const followUser = (id, token) => {
               setError({
                 errorType: AUTHORISATION_ERROR,
                 errorMessage: UNAUTHORISED
+              })
+            );
+          } else if (err.response.data == HAS_BEEN_FOLLOWED) {
+            dispatch(
+              setError({
+                errorType: INVALID_REQUEST,
+                errorMessage: HAS_BEEN_FOLLOWED
+              })
+            );
+          } else if (err.response.data == CANT_BE_FOLLOWED) {
+            dispatch(
+              setError({
+                errorType: INVALID_REQUEST,
+                errorMessage: CANT_BE_FOLLOWED
               })
             );
           }


### PR DESCRIPTION
Refactored PATCH /profile/follow/:id route to prevent users from following themselves. Updated `followUser` action and tests to reflect the changes to the route.
closes #93 